### PR TITLE
Limiting permission for changing marked as correct status

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -11,6 +11,7 @@ const db = require('../database');
 const meta = require('../meta');
 const analytics = require('../analytics');
 const user = require('../user');
+const groups = require('../groups');
 const plugins = require('../plugins');
 const utils = require('../utils');
 const slugify = require('../slugify');
@@ -68,6 +69,9 @@ async function registerAndLoginUser(req, res, userData) {
     const next = req.session.returnTo || `${nconf.get('relative_path')}/`;
     const complete = await plugins.hooks.fire('filter:register.complete', { uid: uid, next: next });
     req.session.returnTo = complete.next;
+    if (userData['account-type'] === 'instructor') {
+        groups.join('instructors', uid);
+    }
     return complete;
 }
 

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -62,22 +62,24 @@ module.exports = function (Posts) {
 
     // Posts.endorse = async function (pid: number, uid: number) {
     Posts.endorse = async function (pid, uid) {
+        const isInstr = await user.isInstructor(uid);
         const isAdmin = await user.isAdministrator(uid);
-        if (isAdmin) {
+        if (isInstr || isAdmin) {
             return await toggleEndorse('endorse', pid, uid);
         }
-        if (!isAdmin) {
+        if (!isInstr && !isAdmin) {
             throw new Error('[[error:not-instructor]]');
         }
     };
 
     // Posts.unendorse = async function (pid: number, uid: number) {
     Posts.unendorse = async function (pid, uid) {
+        const isInstr = await user.isInstructor(uid);
         const isAdmin = await user.isAdministrator(uid);
-        if (isAdmin) {
+        if (isInstr || isAdmin) {
             return await toggleEndorse('unendorse', pid, uid);
         }
-        if (!isAdmin) {
+        if (!isInstr && !isAdmin) {
             throw new Error('[[error:not-instructor]]');
         }
     };

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -65,7 +65,7 @@ module.exports = function (Posts) {
         const isAdmin = await user.isAdministrator(uid);
         if (isAdmin) {
             return await toggleEndorse('endorse', pid, uid);
-        } 
+        }
         if (!isAdmin) {
             throw new Error('[[error:not-instructor]]');
         }

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -2,6 +2,7 @@
 
 // import db from '../database';
 const db = require('../database');
+const user = require('../user');
 
 // interface PostHandlerType {
 //     endorse: (pid: number, uid: number) => Promise<ToggleEndorseResult>;
@@ -61,12 +62,24 @@ module.exports = function (Posts) {
 
     // Posts.endorse = async function (pid: number, uid: number) {
     Posts.endorse = async function (pid, uid) {
-        return await toggleEndorse('endorse', pid, uid);
+        const isAdmin = await user.isAdministrator(uid);
+        if(isAdmin){
+            return await toggleEndorse('endorse', pid, uid);
+        } else {
+            throw new Error('[[error:not-instructor]]');
+        }
+        //return await toggleEndorse('endorse', pid, uid);
     };
 
     // Posts.unendorse = async function (pid: number, uid: number) {
     Posts.unendorse = async function (pid, uid) {
-        return await toggleEndorse('unendorse', pid, uid);
+        const isAdmin = await user.isAdministrator(uid);
+        if(isAdmin){
+            return await toggleEndorse('unendorse', pid, uid);
+        } else {
+            throw new Error('[[error:not-instructor]]');
+        }
+        //return await toggleEndorse('unendorse', pid, uid);
     };
 
     // Posts.hasEndorsed = async function (pid): Promise<BoolOrBoolArr> {

--- a/src/posts/endorse.js
+++ b/src/posts/endorse.js
@@ -63,23 +63,23 @@ module.exports = function (Posts) {
     // Posts.endorse = async function (pid: number, uid: number) {
     Posts.endorse = async function (pid, uid) {
         const isAdmin = await user.isAdministrator(uid);
-        if(isAdmin){
+        if (isAdmin) {
             return await toggleEndorse('endorse', pid, uid);
-        } else {
+        } 
+        if (!isAdmin) {
             throw new Error('[[error:not-instructor]]');
         }
-        //return await toggleEndorse('endorse', pid, uid);
     };
 
     // Posts.unendorse = async function (pid: number, uid: number) {
     Posts.unendorse = async function (pid, uid) {
         const isAdmin = await user.isAdministrator(uid);
-        if(isAdmin){
+        if (isAdmin) {
             return await toggleEndorse('unendorse', pid, uid);
-        } else {
+        }
+        if (!isAdmin) {
             throw new Error('[[error:not-instructor]]');
         }
-        //return await toggleEndorse('unendorse', pid, uid);
     };
 
     // Posts.hasEndorsed = async function (pid): Promise<BoolOrBoolArr> {

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -15,6 +15,10 @@ privsUsers.isAdministrator = async function (uid) {
     return await isGroupMember(uid, 'administrators');
 };
 
+privsUsers.isInstructor = async function (uid) {
+    return await isGroupMember(uid, 'instructors');
+};
+
 privsUsers.isGlobalModerator = async function (uid) {
     return await isGroupMember(uid, 'Global Moderators');
 };

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -149,6 +149,10 @@ User.isAdministrator = async function (uid) {
     return await privileges.users.isAdministrator(uid);
 };
 
+User.isInstructor = async function (uid) {
+    return await privileges.users.isInstructor(uid);
+};
+
 User.isGlobalModerator = async function (uid) {
     return await privileges.users.isGlobalModerator(uid);
 };

--- a/test/posts.js
+++ b/test/posts.js
@@ -305,16 +305,20 @@ describe('Post\'s', () => {
     describe('endorsing', () => {
         it('should endorse a post if the endorser is admin', async () => {
             const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            assert.equal(data.isEndorsed, true);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-            assert.equal(hasEndorsed, true);
+            if (user.isAdministrator(voterUid)) {
+                assert.equal(data.isEndorsed, true);
+                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+                assert.equal(hasEndorsed, true);
+            }
         });
 
         it('should unendorse a post if the endorser is admin', async () => {
             const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            assert.equal(data.isEndorsed, false);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-            assert.equal(hasEndorsed, false);
+            if (user.isAdministrator(voterUid)) {
+                assert.equal(data.isEndorsed, false);
+                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+                assert.equal(hasEndorsed, false);
+            }
         });
     });
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -27,7 +27,7 @@ const helpers = require('./helpers');
 describe('Post\'s', () => {
     let voterUid;
     let voteeUid;
-    let adminUid;
+    let instructorUid;
     let globalModUid;
     let postData;
     let topicData;
@@ -38,7 +38,7 @@ describe('Post\'s', () => {
             voterUid: function (next) {
                 user.create({ username: 'upvoter' }, next);
             },
-            adminUid: function (next) {
+            instructorUid: function (next) {
                 user.create({ username: 'admin' }, next);
             },
             voteeUid: function (next) {
@@ -60,7 +60,7 @@ describe('Post\'s', () => {
 
             voterUid = results.voterUid;
             voteeUid = results.voteeUid;
-            adminUid = results.adminUid;
+            instructorUid = results.instructorUid;
             globalModUid = results.globalModUid;
             cid = results.category.cid;
 
@@ -75,7 +75,7 @@ describe('Post\'s', () => {
                 }
                 postData = data.postData;
                 topicData = data.topicData;
-                groups.join('administrators', adminUid);
+                groups.join('instructors', instructorUid);
                 groups.join('Global Moderators', globalModUid, done);
             });
         });
@@ -308,7 +308,7 @@ describe('Post\'s', () => {
     });
 
     describe('endorsing', () => {
-        it('should not endorse a post if the endorser is not admin', async () => {
+        it('should not endorse a post if the endorser is not instructor', async () => {
             try {
                 await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             } catch (err) {
@@ -316,7 +316,7 @@ describe('Post\'s', () => {
             }
         });
 
-        it('should not unendorse a post if the endorser is not admin', async () => {
+        it('should not unendorse a post if the endorser is not instructor', async () => {
             try {
                 await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             } catch (err) {
@@ -324,17 +324,17 @@ describe('Post\'s', () => {
             }
         });
 
-        it('should endorse a post if the endorser is admin', async () => {
-            const data = await apiPosts.endorse({ uid: adminUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+        it('should endorse a post if the endorser is instructor', async () => {
+            const data = await apiPosts.endorse({ uid: instructorUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, true);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, adminUid);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, instructorUid);
             assert.equal(hasEndorsed, true);
         });
 
-        it('should unendorse a post if the endorser is admin', async () => {
-            const data = await apiPosts.unendorse({ uid: adminUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+        it('should unendorse a post if the endorser is instructor', async () => {
+            const data = await apiPosts.unendorse({ uid: instructorUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, false);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, adminUid);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, instructorUid);
             assert.equal(hasEndorsed, false);
         });
     });

--- a/test/posts.js
+++ b/test/posts.js
@@ -27,6 +27,7 @@ const helpers = require('./helpers');
 describe('Post\'s', () => {
     let voterUid;
     let voteeUid;
+    let adminUid;
     let globalModUid;
     let postData;
     let topicData;
@@ -36,6 +37,9 @@ describe('Post\'s', () => {
         async.series({
             voterUid: function (next) {
                 user.create({ username: 'upvoter' }, next);
+            },
+            adminUid: function (next) {
+                user.create({ username: 'admin' }, next);
             },
             voteeUid: function (next) {
                 user.create({ username: 'upvotee' }, next);
@@ -56,6 +60,7 @@ describe('Post\'s', () => {
 
             voterUid = results.voterUid;
             voteeUid = results.voteeUid;
+            adminUid = results.adminUid;
             globalModUid = results.globalModUid;
             cid = results.category.cid;
 
@@ -70,7 +75,7 @@ describe('Post\'s', () => {
                 }
                 postData = data.postData;
                 topicData = data.topicData;
-
+                groups.join('administrators', adminUid);
                 groups.join('Global Moderators', globalModUid, done);
             });
         });
@@ -318,21 +323,20 @@ describe('Post\'s', () => {
                 return assert.equal(err.message, '[[error:not-instructor]]');
             }
         });
-        /*
-        it('should not endorse a post if the endorser is not admin', async () => {
-            const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+        
+        it('should endorse a post if the endorser is admin', async () => {
+            const data = await apiPosts.endorse({ uid: adminUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, true);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, adminUid);
             assert.equal(hasEndorsed, true);
         });
 
         it('should unendorse a post if the endorser is admin', async () => {
-            const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            const data = await apiPosts.unendorse({ uid: adminUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, false);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, adminUid);
             assert.equal(hasEndorsed, false);
         });
-        */
     });
 
     describe('post tools', () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -303,18 +303,22 @@ describe('Post\'s', () => {
     });
 
     describe('endorsing', () => {
-        it('should endorse a post', async () => {
+        it('should endorse a post if the endorser is admin', async () => {
             const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            assert.equal(data.isEndorsed, true);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-            assert.equal(hasEndorsed, true);
+            if (user.isAdminOrGlobalMod(uid)) {
+                assert.equal(data.isEndorsed, true);
+                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+                assert.equal(hasEndorsed, true);
+            }
         });
 
-        it('should unendorse a post', async () => {
+        it('should unendorse a post if the endorser is admin', async () => {
             const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            assert.equal(data.isEndorsed, false);
-            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-            assert.equal(hasEndorsed, false);
+            if (user.isAdminOrGlobalMod(uid)) {
+                assert.equal(data.isEndorsed, false);
+                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+                assert.equal(hasEndorsed, false);
+            }
         });
     });
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -305,20 +305,16 @@ describe('Post\'s', () => {
     describe('endorsing', () => {
         it('should endorse a post if the endorser is admin', async () => {
             const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            if (user.isAdminOrGlobalMod(uid)) {
-                assert.equal(data.isEndorsed, true);
-                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-                assert.equal(hasEndorsed, true);
-            }
+            assert.equal(data.isEndorsed, true);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            assert.equal(hasEndorsed, true);
         });
 
         it('should unendorse a post if the endorser is admin', async () => {
             const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            if (user.isAdminOrGlobalMod(uid)) {
-                assert.equal(data.isEndorsed, false);
-                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-                assert.equal(hasEndorsed, false);
-            }
+            assert.equal(data.isEndorsed, false);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            assert.equal(hasEndorsed, false);
         });
     });
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -323,7 +323,7 @@ describe('Post\'s', () => {
                 return assert.equal(err.message, '[[error:not-instructor]]');
             }
         });
-        
+
         it('should endorse a post if the endorser is admin', async () => {
             const data = await apiPosts.endorse({ uid: adminUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
             assert.equal(data.isEndorsed, true);

--- a/test/posts.js
+++ b/test/posts.js
@@ -303,23 +303,36 @@ describe('Post\'s', () => {
     });
 
     describe('endorsing', () => {
-        it('should endorse a post if the endorser is admin', async () => {
-            const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            if (user.isAdministrator(voterUid)) {
-                assert.equal(data.isEndorsed, true);
-                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-                assert.equal(hasEndorsed, true);
+        it('should not endorse a post if the endorser is not admin', async () => {
+            try {
+                await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            } catch (err) {
+                return assert.equal(err.message, '[[error:not-instructor]]');
             }
+        });
+
+        it('should not unendorse a post if the endorser is not admin', async () => {
+            try {
+                await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            } catch (err) {
+                return assert.equal(err.message, '[[error:not-instructor]]');
+            }
+        });
+        /*
+        it('should not endorse a post if the endorser is not admin', async () => {
+            const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            assert.equal(data.isEndorsed, true);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            assert.equal(hasEndorsed, true);
         });
 
         it('should unendorse a post if the endorser is admin', async () => {
             const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
-            if (user.isAdministrator(voterUid)) {
-                assert.equal(data.isEndorsed, false);
-                const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
-                assert.equal(hasEndorsed, false);
-            }
+            assert.equal(data.isEndorsed, false);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            assert.equal(hasEndorsed, false);
         });
+        */
     });
 
     describe('post tools', () => {


### PR DESCRIPTION
This PR addresses the issue of non-instructors being able to mark posts as correct, by introducing functions that check for permissions.

The key change is simply a call to isAdmin within both Post.endorse and Post.unendorse, and an error being thrown if a non-admin attempts to mark a post as correct. Tests have been updated accordingly.

Any review and feedback is appreciated.