### PR TITLE
Fix Initial Endorsement Status Issue (#17)

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -237,7 +237,7 @@ define('forum/topic/events', [
 
         const post = $('[data-pid="' + data.post.pid + '"]').closest('[component="post"]');
         post.toggleClass('endorsed', data.isEndorsed);
-    
+
         el.find('[component="post/endorse/on"]').toggleClass('hidden', !data.isEndorsed);
         el.find('[component="post/endorse/off"]').toggleClass('hidden', data.isEndorsed);
     }

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -234,8 +234,10 @@ define('forum/topic/events', [
         }
 
         el.attr('data-endorsed', data.isEndorsed);
-        el.toggleClass('endorsed', data.endorse);
 
+        const post = $('[data-pid="' + data.post.pid + '"]').closest('[component="post"]');
+        post.toggleClass('endorsed', data.isEndorsed);
+    
         el.find('[component="post/endorse/on"]').toggleClass('hidden', !data.isEndorsed);
         el.find('[component="post/endorse/off"]').toggleClass('hidden', data.isEndorsed);
     }

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -234,6 +234,7 @@ module.exports = function (Topics) {
 
         postData.votes = 0;
         postData.bookmarked = false;
+        postData.endorsed = false;
         postData.display_edit_tools = true;
         postData.display_delete_tools = true;
         postData.display_moderator_tools = true;

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -116,12 +116,14 @@ module.exports = function (Topics) {
         }
         const [
             bookmarks,
+            endorseData,
             voteData,
             userData,
             editors,
             replies,
         ] = await Promise.all([
             posts.hasBookmarked(pids, uid),
+            posts.hasEndorsed(pids, uid),
             posts.getVoteStatusByPostIDs(pids, uid),
             getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
             getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug'])),
@@ -134,6 +136,7 @@ module.exports = function (Topics) {
                 postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
                 postObj.editor = postObj.editor ? editors[postObj.editor] : null;
                 postObj.bookmarked = bookmarks[i];
+                postObj.endorsed = endorseData;
                 postObj.upvoted = voteData.upvotes[i];
                 postObj.downvoted = voteData.downvotes[i];
                 postObj.votes = postObj.votes || 0;

--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -148,6 +148,16 @@
 		margin-left: 5px;
 	}
 
+	.endorsed {
+		background-image: linear-gradient(to bottom, #d8feda, #a2ee95, #8af07d);
+	}
+
+	.endorsed-text {
+		text-align: center; 
+		color: white; 
+		font-weight: bold;
+	}
+
 	[component="post/anchor"] {
 		position: relative;
 		top: -@post-padding;

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
@@ -2,11 +2,13 @@
     <a href="#" data-toggle="dropdown" data-ajaxify="false"><i class="fa fa-fw fa-ellipsis-v"></i></a>
     <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li>
-            <a component="post/endorse" role="menuitem" tabindex="-1" data-endorsed="{posts.isEndorsed}" href="#">
-                <span>
-                    <i component="post/endorse/on" <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">Mark post as Correct</i>
-                    <i component="post/endorse/off" <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Unmark post</i>
+            <a component="post/endorse" role="menuitem" tabindex="-1" href="#" data-endorsed="{posts.endorsed}">
+                <span class="menu-icon">
+                    <i component="post/endorse/on" class="fas fa-check-circle <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
+                    <i component="post/endorse/off" class="fas fa-circle <!-- IF !posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
                 </span>
+                <span component="post/endorse/on" class="endorse-text <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Mark Post as Correct</span>
+                <span component="post/endorse/off" class="endorse-text <!-- IF !posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Unmark Post</span>
             </a>
         </li>
     </ul>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
@@ -4,11 +4,11 @@
         <li>
             <a component="post/endorse" role="menuitem" tabindex="-1" href="#" data-endorsed="{posts.endorsed}">
                 <span class="menu-icon">
-                    <i component="post/endorse/on" class="fas fa-check-circle <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
-                    <i component="post/endorse/off" class="fas fa-circle <!-- IF !posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
+                    <i component="post/endorse/on" class="fas fa-circle <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->"></i>
+                    <i component="post/endorse/off" class="fas fa-check-circle <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
                 </span>
-                <span component="post/endorse/on" class="endorse-text <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Mark Post as Correct</span>
-                <span component="post/endorse/off" class="endorse-text <!-- IF !posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Unmark Post</span>
+                <span component="post/endorse/on" class="endorse-text <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">Unmark Post</span>
+                <span component="post/endorse/off" class="endorse-text <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Mark Post as Correct</span>
             </a>
         </li>
     </ul>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -53,12 +53,6 @@
     {posts.content}
 </div>
 
-{{{if posts.hasEndorsed}}}
-<div style="text-align:center; color=#1CC000; font-weight:bold;">
-    <span>~ Instructor has marked this answer correct ~</span>
-</div>
-{{{ end }}}
-
 <div class="post-footer">
     {{{ if posts.user.signature }}}
     <div component="post/signature" data-uid="{posts.user.uid}" class="post-signature">{posts.user.signature}</div>

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -84,7 +84,6 @@
                     <!-- IMPORT partials/topic/post.tpl -->
                 </li>
                 {renderTopicEvents(@index, config.topicPostSort)}
-                {{{end}}}
             {{{end}}}
         </ul> 
 

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -64,18 +64,7 @@
         
         <ul component="topic" class="posts timeline" data-tid="{tid}" data-cid="{cid}">
             {{{each posts}}}
-                {{{if posts.hasEndorsed}}}
-                <li component="post" style="background-color:#F8FFEE;" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
-                    <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
-
-                    <meta itemprop="datePublished" content="{posts.timestampISO}">
-                    <meta itemprop="dateModified" content="{posts.editedISO}">
-
-                    <!-- IMPORT partials/topic/post.tpl -->
-                </li>
-                {renderTopicEvents(@index, config.topicPostSort)}
-                {{{else}}}
-                <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+                <li component="post" class="{{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}} {{{ if posts.endorsed }}}endorsed{{{ end }}} <!-- IMPORT partials/data/topic.tpl -->">
                     <a component="post/anchor" data-index="{posts.index}" id="{posts.index}"></a>
 
                     <meta itemprop="datePublished" content="{posts.timestampISO}">


### PR DESCRIPTION
Addresses the bug where the initial endorsement status is set to 'undefined'. This PR ensures that the status is correctly initialized as either 'endorsed' or 'unendorsed' based on user endorsement.

This pull request closes issue #17.