### PR TITLE
Debug the instructor endorse text 

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -237,7 +237,7 @@ define('forum/topic/events', [
 
         const post = $('[data-pid="' + data.post.pid + '"]').closest('[component="post"]');
         post.toggleClass('endorsed', data.isEndorsed);
-
+        post.find('[component="post/endorse/on"]').toggleClass('hidden', !data.isEndorsed);
         el.find('[component="post/endorse/on"]').toggleClass('hidden', !data.isEndorsed);
         el.find('[component="post/endorse/off"]').toggleClass('hidden', data.isEndorsed);
     }

--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -152,9 +152,10 @@
 		background-image: linear-gradient(to bottom, #d8feda, #a2ee95, #8af07d);
 	}
 
-	.endorsed-text {
+	.endorse-text {
 		text-align: center; 
-		color: white; 
+		color: #1CC000; 
+		font-size: 12px; 
 		font-weight: bold;
 	}
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -53,6 +53,8 @@
     {posts.content}
 </div>
 
+<p component="post/endorse/on" class="endorse-text <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">~An Instructor has endorsed the post.~</p>
+
 <div class="post-footer">
     {{{ if posts.user.signature }}}
     <div component="post/signature" data-uid="{posts.user.uid}" class="post-signature">{posts.user.signature}</div>


### PR DESCRIPTION
Based on the backend isEndorse function, the highlight of endorsed post was correctly implemented but no the text. Thus, this PR shows how the instructor endorsed text is fixed. At first it had the problem of not instantly reflecting the changes of endorsed and not endorsed status; however, after the toggle function has been implemented properly, the endorse text is appearing correctly with the design properly showing. 


https://github.com/CMU-313/fall23-nodebb-softwear/assets/82299804/1d0fb072-6208-489c-aec0-dc38e0b303c2

