### PR TITLE
Fix Endorse Background Color & Endorse Option Text 

### DIFF
--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -152,6 +152,13 @@
 		background-color: #F8FFEE; 
 	}
 
+	.endorse-option{
+		padding-left: 5px;
+		color:black;
+		font-weight:400;
+		font-size: 14px;  
+	}
+
 	.endorse-text {
 		text-align: center; 
 		color: #1CC000; 

--- a/themes/nodebb-theme-persona/less/topic.less
+++ b/themes/nodebb-theme-persona/less/topic.less
@@ -149,7 +149,7 @@
 	}
 
 	.endorsed {
-		background-image: linear-gradient(to bottom, #d8feda, #a2ee95, #8af07d);
+		background-color: #F8FFEE; 
 	}
 
 	.endorse-text {

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
@@ -7,8 +7,8 @@
                     <i component="post/endorse/on" class="fas fa-circle <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->"></i>
                     <i component="post/endorse/off" class="fas fa-check-circle <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->"></i>
                 </span>
-                <span component="post/endorse/on" class="endorse-text <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">Unmark Post</span>
-                <span component="post/endorse/off" class="endorse-text <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Mark Post as Correct</span>
+                <span component="post/endorse/on" class="endorse-option <!-- IF !posts.endorsed -->hidden<!-- ENDIF !posts.endorsed -->">Unmark Post</span>
+                <span component="post/endorse/off" class="endorse-option <!-- IF posts.endorsed -->hidden<!-- ENDIF posts.endorsed -->">Mark Post as Correct</span>
             </a>
         </li>
     </ul>


### PR DESCRIPTION
The gradient color of endorsed posts have been changed to a lighter solid color using a background-color instead of background-image.
The endorse option texts were tied to the same class as the endorsed text. The two classes have been separated to give different designs. 

<img width="1792" alt="image" src="https://github.com/CMU-313/fall23-nodebb-softwear/assets/82299804/e1d89e27-8d10-485b-9052-3de8dde895f2">
