### PR TITLE
Removing ability for non-instructors to open the endorse menu

### DIFF
--- a/public/openapi/components/schemas/UserObject.yaml
+++ b/public/openapi/components/schemas/UserObject.yaml
@@ -409,6 +409,8 @@ UserObjectFull:
       type: boolean
     isGlobalModerator:
       type: boolean
+    isInstr:
+      type: boolean
     isModerator:
       type: boolean
     isAdminOrGlobalModerator:

--- a/src/groups/user.js
+++ b/src/groups/user.js
@@ -49,6 +49,7 @@ module.exports = function (Groups) {
             Promise.all(privateGroups.map(group => Groups.ownership.isOwner(uid, group.name))),
             user.isAdministrator(uid),
             user.isGlobalModerator(uid),
+            user.isInstructor(uid),
         ]);
         const ownGroups = privateGroups.filter((group, index) => ownership[index]);
 

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -77,6 +77,7 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
 
     const results = await utils.promiseParallel({
         isAdmin: user.isAdministrator(req.uid),
+        isInstr: user.isInstructor(req.uid),
         isGlobalMod: user.isGlobalModerator(req.uid),
         isModerator: user.isModeratorOfAnyCategory(req.uid),
         privileges: privileges.global.get(req.uid),
@@ -97,6 +98,7 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
 
     results.user.unreadData = unreadData;
     results.user.isAdmin = results.isAdmin;
+    results.user.isInstr = results.isInstr;
     results.user.isGlobalMod = results.isGlobalMod;
     results.user.isMod = !!results.isModerator;
     results.user.privileges = results.privileges;
@@ -119,6 +121,7 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
         unreadData,
     }));
     templateValues.isAdmin = results.user.isAdmin;
+    templateValues.isInstr = results.user.isInstr;
     templateValues.isGlobalMod = results.user.isGlobalMod;
     templateValues.showModMenu = results.user.isAdmin || results.user.isGlobalMod || results.user.isMod;
     templateValues.canChat = results.privileges.chat && meta.config.disableChat !== 1;

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -21,6 +21,7 @@ module.exports = function (SocketPosts) {
         const results = await utils.promiseParallel({
             posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId']),
             isAdmin: user.isAdministrator(socket.uid),
+            isInstr: user.isInstructor(socket.uid),
             isGlobalMod: user.isGlobalModerator(socket.uid),
             isModerator: user.isModerator(socket.uid, data.cid),
             canEdit: privileges.posts.canEdit(data.pid, socket.uid),

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -158,8 +158,12 @@ module.exports = function (Topics) {
         return result.posts;
     };
 
-    Topics.modifyPostsByPrivilege = function (topicData, topicPrivileges) {
+    Topics.modifyPostsByPrivilege = async function (topicData, topicPrivileges) {
         const loggedIn = parseInt(topicPrivileges.uid, 10) > 0;
+
+        // you have to do the awaits seperately or the logic doesn't work
+        const can_endorse_instr = await user.isInstructor(topicPrivileges.uid);
+        const can_endorse_admin = await user.isAdministrator(topicPrivileges.uid);
         topicData.posts.forEach((post) => {
             if (post) {
                 post.topicOwnerPost = parseInt(topicData.uid, 10) === parseInt(post.uid, 10);
@@ -173,7 +177,7 @@ module.exports = function (Topics) {
                         (post.deleted && parseInt(post.deleterUid, 10) === parseInt(topicPrivileges.uid, 10)))) ||
                     ((loggedIn || topicData.postSharing.length) && !post.deleted);
                 post.ip = topicPrivileges.isAdminOrMod ? post.ip : undefined;
-
+                post.can_display_post = can_endorse_instr || can_endorse_admin;
                 posts.modifyPostByPrivilege(post, topicPrivileges);
             }
         });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -64,6 +64,7 @@ export type UserObjectFull = UserObject & {
   theirid: number;
   isTargetAdmin: boolean;
   isAdmin: boolean;
+  isInstr: boolean;
   isGlobalModerator: boolean;
   isModerator: boolean;
   isAdminOrGlobalModerator: boolean;

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -160,6 +160,7 @@ User.isGlobalModerator = async function (uid) {
 User.getPrivileges = async function (uid) {
     return await utils.promiseParallel({
         isAdmin: User.isAdministrator(uid),
+        isInstr: User.isInstructor(uid),
         isGlobalModerator: User.isGlobalModerator(uid),
         isModeratorOfAnyCategory: User.isModeratorOfAnyCategory(uid),
     });

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu.tpl
@@ -1,4 +1,5 @@
 <span component="post/tools" class="dropdown moderator-tools bottom-sheet <!-- IF !posts.display_post_menu -->hidden<!-- ENDIF !posts.display_post_menu -->">
+    {{{ if posts.can_display_post }}}
     <a href="#" data-toggle="dropdown" data-ajaxify="false"><i class="fa fa-fw fa-ellipsis-v"></i></a>
     <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li>
@@ -12,4 +13,5 @@
             </a>
         </li>
     </ul>
+    {{{ end }}}
 </span>


### PR DESCRIPTION
This PR addresses the issue that a non-instructor can click the drop-down menu to endorse a post, and get thrown an error, instead of not being able to access the drop-down menu at all. Now, non-instructors will not even see the menu in their view of the NodeBB forum.

I found out too late that I was committing to the wrong branch, so I had to checkout a new branch after all was said and done, which is why the commit count is low.